### PR TITLE
Simulate timed gamepad input and assert keystroke timing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,18 +45,33 @@ Key building blocks:
 - **`get_button(pressed_buttons)`** maps the first pressed entry in the raw button list to a
   label (`A`, `B`, ... `M`) by index. Index order is the pygame button order for the controller.
 
-The main loop (60 fps via `pygame.time.Clock`): the **right stick** moves the cursor (arrow
-keys); when the right stick is neutral, a face button + **left stick** direction looks up a
-character in `LAYER_DIR_LETTER_MAP`. Neutral-left-stick keys are sent with `keyboard.send`
-(named keys), others are typed with `keyboard.write`. Repeated identical keys sleep longer
-(0.3s vs 0.1s) to debounce held inputs.
+- **`process_frame(controller, key_map, output)`** runs one polling frame and returns
+  `("cursor", None)`, `("key", char)`, or `("idle", None)`. The **right stick** moves the
+  cursor (arrow keys); when it's neutral, a face button + **left stick** direction looks up a
+  character in `key_map`. Neutral-left-stick keys are sent with `output.send` (named keys),
+  others typed with `output.write`. `output` is anything with `.send`/`.write` — the `keyboard`
+  module in production.
+- **`run_loop(controller, key_map, output=keyboard, *, sleep, tick, poll_events, should_continue)`**
+  is the polling loop, with all side-effecting collaborators injected (production defaults make
+  the real path unchanged). It owns `prev_key` and the debounce: repeated identical keys sleep
+  longer (0.3s vs 0.1s); cursor frames always sleep 0.1s and never touch `prev_key`. QUIT (from
+  `poll_events`) stops it. The `__main__` block is thin wiring: build the key map and call
+  `run_loop(..., tick=lambda: clock.tick(60))` (60 fps).
 
 ## Testing notes
 
-`pygame` and `keyboard` *are* installed in the synced environment, but `tests/test_main.py`
-still mocks both via `sys.modules[...] = MagicMock()` *before* `from joyboard import main`, so
-the module-level imports resolve without a real controller/display. Any new test module that
-imports `main` must do the same mock setup first, or the import will fail. Tests cover the pure
-functions only — the main loop is not exercised.
+`pygame` and `keyboard` *are* installed in the synced environment, but the tests mock both via
+`sys.modules[...] = MagicMock()` *before* `from joyboard import main`, so the module-level
+imports resolve without a real controller/display. `tests/test_main.py` does this inline; any
+other test module that imports `main` must do the same — or just import `tests/harness.py`,
+which centralizes the mock guard.
+
+`tests/test_main.py` covers the pure functions (`load_key_map`, `get_direction`, `get_button`).
+`tests/test_loop.py` exercises the full `run_loop`/`process_frame` path using the harness in
+`tests/harness.py`: a `VirtualClock` (sleep advances virtual time, no real delay), a
+`ScriptedController` driven by a `Hold(t0, t1, left=, right=, button=)` timeline with explicit
+press/release timestamps, and a `KeyboardRecorder` capturing `(time, "send"/"write", key)`.
+Author a test with `run_scripted([...holds])` and assert the returned timed keystroke list —
+this is how debounce/repeat timing is verified deterministically.
 
 The package version is static in `pyproject.toml` (`project.version`).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,8 @@ module-root = "src"
 src = ["src", "tests"]
 
 [tool.ty.environment]
-root = ["./src"]
+# ./src so `joyboard` resolves; "." so test modules can import the `tests` package.
+root = ["./src", "."]
 
 [tool.coverage.run]
 source_pkgs = ["joyboard", "tests"]

--- a/src/joyboard/main.py
+++ b/src/joyboard/main.py
@@ -3,8 +3,6 @@ from time import sleep
 import keyboard
 import pygame
 
-LAYER_DIR_LETTER_MAP = {}
-
 
 def load_key_map():
     DIRECTION_BUTTON_TABLE = """
@@ -95,6 +93,73 @@ def get_button(pressed_buttons):
             return "M"
 
 
+CURSOR_ARROWS = {"N": "up", "E": "right", "S": "down", "W": "left"}
+
+
+def process_frame(controller, key_map, output):
+    """Run one frame of input handling, emitting keystrokes via output.
+
+    output must expose .send(key) and .write(key) (the keyboard module does).
+    Returns one of:
+      ("cursor", None) - right stick moved (an arrow may have been sent)
+      ("key", key)     - a character/special key was emitted for a button press
+      ("idle", None)   - nothing happened this frame
+    """
+    move_cursor = get_direction(controller, "R")
+    if move_cursor != "X":
+        arrow = CURSOR_ARROWS.get(move_cursor)
+        if arrow is not None:
+            output.send(arrow)
+        return ("cursor", None)
+
+    raw_button_input = [
+        controller.get_button(i) for i in range(controller.get_numbuttons())
+    ]
+    if any(raw_button_input):
+        button = get_button(raw_button_input)
+        direction = get_direction(controller, "L")
+        key = key_map[(direction, button)]
+        if direction == "X":
+            output.send(key)
+        else:
+            output.write(key)
+        return ("key", key)
+
+    return ("idle", None)
+
+
+def run_loop(
+    controller,
+    key_map,
+    output=keyboard,
+    *,
+    sleep=sleep,
+    tick=None,
+    poll_events=pygame.event.get,
+    should_continue=None,
+):
+    """Poll the controller and emit keystrokes until QUIT or should_continue()."""
+    prev_key = None
+    running = True
+    while running:
+        for event in poll_events():
+            if event.type == pygame.QUIT:
+                running = False
+
+        kind, key = process_frame(controller, key_map, output)
+        if kind == "cursor":
+            sleep(0.1)
+        elif kind == "key":
+            sleep(0.3 if prev_key == key else 0.1)
+            prev_key = key
+
+        if tick is not None:
+            tick()
+
+        if should_continue is not None and not should_continue():
+            running = False
+
+
 if __name__ == "__main__":
     pygame.init()
 
@@ -102,55 +167,10 @@ if __name__ == "__main__":
     controller.init()
     clock = pygame.time.Clock()
 
-    LAYER_DIR_LETTER_MAP = load_key_map()
-    prev_key = None
+    key_map = load_key_map()
 
     try:
-        running = True
-        while running:
-            a_button = 0
-
-            # Check for events
-            for event in pygame.event.get():
-                if event.type == pygame.QUIT:
-                    running = False
-
-            move_cursor = get_direction(controller, "R")
-            if move_cursor != "X":
-                match move_cursor:
-                    case "N":
-                        keyboard.send("up")
-                    case "E":
-                        keyboard.send("right")
-                    case "S":
-                        keyboard.send("down")
-                    case "W":
-                        keyboard.send("left")
-                sleep(0.1)
-
-            else:
-                raw_buttom_input = [
-                    controller.get_button(i) for i in range(controller.get_numbuttons())
-                ]
-                if any(raw_buttom_input):
-                    buttom = get_button(raw_buttom_input)
-                    direction = get_direction(controller, "L")
-                    # print(direction, buttom)
-                    if direction == "X":
-                        key = LAYER_DIR_LETTER_MAP[(direction, buttom)]
-                        keyboard.send(key)
-                    else:
-                        key = LAYER_DIR_LETTER_MAP[(direction, buttom)]
-                        keyboard.write(key)
-
-                    if prev_key == key:
-                        sleep(0.3)
-                    else:
-                        sleep(0.1)
-                    prev_key = key
-
-            clock.tick(60)
-
+        run_loop(controller, key_map, tick=lambda: clock.tick(60))
     finally:
         # Clean up
         print(">> cleaning up")

--- a/tests/harness.py
+++ b/tests/harness.py
@@ -1,0 +1,170 @@
+"""Test harness for simulating human controller input with precise timing.
+
+A test author scripts a timeline of :class:`Hold` intervals (each with explicit
+press/release timestamps) and replays them through the real ``main.run_loop`` via
+:func:`run_scripted`, which returns the exact sequence *and* virtual timing of the
+emitted keystrokes. No real pygame/keyboard/sleep is used -- a ``VirtualClock``
+stands in for wall-clock time so timing is deterministic.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+# pygame and keyboard touch real hardware/displays; mock them before importing
+# main so its module-level imports resolve in a headless test environment.
+sys.modules.setdefault("pygame", MagicMock())
+sys.modules.setdefault("keyboard", MagicMock())
+
+from joyboard import main
+
+# Inverse of get_direction's value_compass_map: compass label -> (x, y) axes.
+COMPASS_TO_XY = {
+    "N": (0, -1),
+    "NE": (1, -1),
+    "E": (1, 0),
+    "SE": (1, 1),
+    "S": (0, 1),
+    "SW": (-1, 1),
+    "W": (-1, 0),
+    "NW": (-1, -1),
+    "X": (0, 0),
+}
+
+# Inverse of get_button's index table: button label -> button index.
+BUTTON_TO_INDEX = {
+    "A": 0,
+    "B": 1,
+    "X": 2,
+    "Y": 3,
+    "LB": 4,
+    "RB": 5,
+    "<": 6,
+    ">": 7,
+    "LA": 8,
+    "RA": 9,
+    "M": 10,
+}
+
+
+class VirtualClock:
+    """A fake clock whose time only advances when ``sleep`` is called."""
+
+    def __init__(self, start=0.0):
+        self.now = start
+
+    def sleep(self, seconds):
+        self.now += seconds
+
+
+class Hold:
+    """A single human input held over the half-open interval ``[t0, t1)``.
+
+    ``left``/``right`` are compass strings ("N".."NW") or "X"/None for a neutral
+    stick; ``button`` is a face/label string ("A".."M") or None. Half-open
+    intervals make release timing unambiguous: at exactly ``t1`` the input is
+    already released.
+    """
+
+    def __init__(self, t0, t1, *, left=None, right=None, button=None):
+        self.t0 = t0
+        self.t1 = t1
+        self.left = left
+        self.right = right
+        self.button = button
+
+
+class ScriptedController:
+    """A pygame-controller stand-in that reports the held input at the current
+    virtual time, computed from a list of :class:`Hold` intervals."""
+
+    def __init__(self, clock, holds, numbuttons=11):
+        self.clock = clock
+        self.holds = list(holds)
+        self.numbuttons = numbuttons
+
+    def _active_hold(self):
+        now = self.clock.now
+        for hold in self.holds:
+            if hold.t0 <= now < hold.t1:
+                return hold
+        return None
+
+    def next_start(self):
+        """The earliest press time strictly after now, or None."""
+        now = self.clock.now
+        starts = [hold.t0 for hold in self.holds if hold.t0 > now]
+        return min(starts) if starts else None
+
+    def get_numbuttons(self):
+        return self.numbuttons
+
+    def get_axis(self, axis):
+        hold = self._active_hold()
+        if hold is None:
+            return 0.0
+        if axis in (0, 1):
+            x, y = COMPASS_TO_XY.get(hold.left or "X", (0, 0))
+        elif axis in (2, 3):
+            x, y = COMPASS_TO_XY.get(hold.right or "X", (0, 0))
+        else:
+            return 0.0
+        return float(x if axis % 2 == 0 else y)
+
+    def get_button(self, index):
+        hold = self._active_hold()
+        if hold is None or hold.button is None:
+            return False
+        return BUTTON_TO_INDEX.get(hold.button) == index
+
+
+class KeyboardRecorder:
+    """Output sink capturing ``(virtual_time, "send"|"write", key)`` per emit."""
+
+    def __init__(self, clock):
+        self.clock = clock
+        self.events = []
+
+    def send(self, key):
+        self.events.append((self.clock.now, "send", key))
+
+    def write(self, key):
+        self.events.append((self.clock.now, "write", key))
+
+
+def run_scripted(holds, *, key_map=None, numbuttons=11, max_time=None):
+    """Replay scripted holds through the real ``main.run_loop`` and return the
+    list of emitted ``(virtual_time, "send"|"write", key)`` keystroke events."""
+    clock = VirtualClock()
+    if key_map is None:
+        key_map = main.load_key_map()
+    controller = ScriptedController(clock, holds, numbuttons)
+    recorder = KeyboardRecorder(clock)
+
+    holds_end = max((hold.t1 for hold in holds), default=0.0)
+    end = holds_end if max_time is None else min(holds_end, max_time)
+
+    # Idle frames (nothing held) don't sleep, so virtual time would stall on dead
+    # gaps between holds. Detect a stalled frame (time unchanged since the prior
+    # frame) and fast-forward to the next scripted press, or to the end when
+    # nothing remains -- this keeps the loop progressing and guarantees it stops.
+    last = {"now": clock.now}
+
+    def tick():
+        if clock.now == last["now"]:
+            nxt = controller.next_start()
+            clock.now = nxt if nxt is not None else end
+        last["now"] = clock.now
+
+    def should_continue():
+        return clock.now < end
+
+    main.run_loop(
+        controller,
+        key_map,
+        output=recorder,
+        sleep=clock.sleep,
+        tick=tick,
+        poll_events=lambda: [],
+        should_continue=should_continue,
+    )
+    return recorder.events

--- a/tests/test_loop.py
+++ b/tests/test_loop.py
@@ -1,0 +1,147 @@
+"""Timing tests for the main polling loop, driven by the scripted-input harness.
+
+Each test scripts human input on a virtual timeline (explicit press/release
+timestamps) and asserts the exact sequence and virtual timing of the keystrokes
+``run_loop`` emits, including the 0.1s/0.3s debounce behavior.
+"""
+
+import pytest
+
+from tests.harness import (
+    Hold,
+    KeyboardRecorder,
+    ScriptedController,
+    VirtualClock,
+    main,
+    run_scripted,
+)
+
+
+def actions(events):
+    """(action, key) pairs, dropping timestamps."""
+    return [(action, key) for _, action, key in events]
+
+
+def times(events):
+    return [t for t, _, _ in events]
+
+
+def gaps(events):
+    ts = times(events)
+    return [b - a for a, b in zip(ts, ts[1:])]
+
+
+def test_single_tap_emits_one_keystroke():
+    # Press left-stick N + button A, release before the first debounce window.
+    events = run_scripted([Hold(0.0, 0.05, left="N", button="A")])
+    assert events == [(pytest.approx(0.0), "write", "a")]
+
+
+def test_holding_repeats_with_debounce_cadence():
+    # A held combo repeats: 0.1s after the first emit, then every 0.3s.
+    events = run_scripted([Hold(0.0, 0.8, left="N", button="A")])
+    assert actions(events) == [("write", "a")] * 4
+    assert times(events) == pytest.approx([0.0, 0.1, 0.4, 0.7])
+    assert gaps(events) == pytest.approx([0.1, 0.3, 0.3])
+
+
+def test_prev_key_persists_across_idle_gap():
+    # Tap A, then (after an idle gap) hold A again. Because prev_key persists,
+    # the repeats inside the second hold are spaced by the 0.3s same-key debounce.
+    events = run_scripted(
+        [
+            Hold(0.0, 0.05, left="N", button="A"),
+            Hold(0.2, 0.6, left="N", button="A"),
+        ]
+    )
+    assert actions(events) == [("write", "a")] * 3
+    assert times(events) == pytest.approx([0.0, 0.2, 0.5])
+    # The repeat within the second hold used the 0.3s same-key debounce.
+    assert times(events)[2] - times(events)[1] == pytest.approx(0.3)
+
+
+def test_switching_to_a_different_key_uses_short_debounce():
+    # Tap A, then hold E: the first E repeat comes after the 0.1s new-key
+    # debounce (not 0.3s), since the key differs from the previous one.
+    events = run_scripted(
+        [
+            Hold(0.0, 0.05, left="N", button="A"),
+            Hold(0.2, 0.6, left="E", button="A"),
+        ]
+    )
+    assert actions(events) == [("write", "a"), ("write", "e"), ("write", "e")]
+    assert times(events)[2] - times(events)[1] == pytest.approx(0.1)
+
+
+@pytest.mark.parametrize(
+    "right, arrow",
+    [("N", "up"), ("E", "right"), ("S", "down"), ("W", "left")],
+)
+def test_right_stick_taps_send_arrow_keys(right, arrow):
+    events = run_scripted([Hold(0.0, 0.05, right=right)])
+    assert events == [(pytest.approx(0.0), "send", arrow)]
+
+
+def test_right_stick_hold_repeats_arrows_at_tenth_second():
+    # Cursor movement always paces at 0.1s and never touches the repeat debounce.
+    events = run_scripted([Hold(0.0, 0.35, right="N")])
+    assert actions(events) == [("send", "up")] * 4
+    assert gaps(events) == pytest.approx([0.1, 0.1, 0.1])
+
+
+def test_right_stick_takes_priority_over_buttons():
+    # With both sticks/buttons active, the right stick wins and no char is typed.
+    events = run_scripted([Hold(0.0, 0.05, right="N", button="A")])
+    assert events == [(pytest.approx(0.0), "send", "up")]
+
+
+def test_diagonal_right_stick_emits_nothing_but_blocks_buttons():
+    # A diagonal right stick has no arrow mapping: it emits nothing yet still
+    # consumes the frame, so the button branch never runs.
+    events = run_scripted([Hold(0.0, 0.2, right="NE", button="A")])
+    assert events == []
+
+
+@pytest.mark.parametrize(
+    "button, key",
+    [("A", "space"), ("B", "backspace"), ("X", "enter"), ("Y", "tab")],
+)
+def test_neutral_stick_specials_use_send(button, key):
+    # Neutral left stick + face button maps to a named special key sent (not
+    # written) via keyboard.send.
+    events = run_scripted([Hold(0.0, 0.05, button=button)])
+    assert events == [(pytest.approx(0.0), "send", key)]
+
+
+def test_direction_plus_button_character_uses_write():
+    events = run_scripted([Hold(0.0, 0.05, left="SW", button="Y")])
+    assert events == [(pytest.approx(0.0), "write", "!")]
+
+
+def test_no_input_emits_nothing():
+    assert run_scripted([]) == []
+    assert run_scripted([Hold(0.0, 0.1)]) == []
+
+
+class _QuitEvent:
+    def __init__(self):
+        self.type = main.pygame.QUIT
+
+
+def test_quit_event_stops_loop_after_finishing_the_frame():
+    # A QUIT event arriving on the first frame stops the loop -- but that frame
+    # still completes (emits once) before the `while running` check exits. With
+    # no other stop condition, this is what keeps the loop finite.
+    clock = VirtualClock()
+    controller = ScriptedController(clock, [Hold(0.0, 1.0, left="N", button="A")])
+    recorder = KeyboardRecorder(clock)
+
+    main.run_loop(
+        controller,
+        main.load_key_map(),
+        output=recorder,
+        sleep=clock.sleep,
+        poll_events=lambda: [_QuitEvent()],
+    )
+
+    assert actions(recorder.events) == [("write", "a")]


### PR DESCRIPTION
## Summary

Adds a test harness that simulates human controller input with **precise press/release timing** and asserts the exact sequence and timing of emitted keystrokes (including the 0.1s/0.3s debounce). To make this possible, the polling loop is extracted from the `__main__` block into testable functions — the production code path is unchanged.

A test now reads like:

```python
events = run_scripted([Hold(0.0, 0.05, left="N", button="A")])
assert events == [(approx(0.0), "write", "a")]
```

## Changes

**`src/joyboard/main.py` — behavior-preserving refactor**
- Extracted `process_frame(controller, key_map, output)` (one frame's decision, returns `("cursor", None)` / `("key", char)` / `("idle", None)`).
- Extracted `run_loop(...)` (the driver) with injectable `output`, `sleep`, `tick`, `poll_events`, and `should_continue` — production defaults keep the real path identical.
- Removed the `LAYER_DIR_LETTER_MAP` module global; the key map is passed explicitly. `__main__` is now thin wiring.

**`tests/harness.py` (new)**
- `VirtualClock` — `sleep` advances virtual time, no real delay.
- `ScriptedController` — driven by a `Hold(t0, t1, left=, right=, button=)` timeline with explicit press/release timestamps; reports controller state at the current virtual time via inverse compass/button maps, so it round-trips through the real `get_direction`/`get_button`.
- `KeyboardRecorder` — captures `(virtual_time, "send"/"write", key)`.
- `run_scripted(holds)` — replays a timeline through the real `run_loop` and returns the timed keystroke list. Idle gaps are fast-forwarded so timing within continuous holds stays exact.

**`tests/test_loop.py` (new)** — covers single taps, the 0.1s-then-0.3s repeat cadence, `prev_key` persistence across idle gaps, switching keys (0.1s vs 0.3s), cursor arrows at 0.1s pacing, right-stick priority over buttons, the diagonal-emits-nothing-but-blocks-buttons case, neutral-stick specials using `send` (space/backspace/enter/tab), and QUIT stopping the loop after finishing the frame.

**`pyproject.toml`** — added the project root to `[tool.ty.environment].root` so ty can resolve the cross-module `tests.harness` import.

**`CLAUDE.md`** — updated architecture and testing notes to describe `run_loop`/`process_frame` and the new harness.

## Verification

- `uv run pytest tests` — **41 passed** (23 original + 18 new)
- `uv run ruff format --check` — clean
- `uv run ty check` — passes
- Coverage of `src/joyboard/main.py` rose from the loop being entirely unexercised to **97%**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TkGfEgPzctrfjhNg1swNwc)_