### PR TITLE
Add project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - [Installation](#installation)
 - [Usage](#usage)
 - [Controls](#controls)
+- [Roadmap](#roadmap)
 - [License](#license)
 
 ## Purpose
@@ -78,6 +79,12 @@ Special actions are mapped to face buttons when the left stick is in the neutral
 | **X** | enter |
 | **Y** | tab |
 
+
+## Roadmap
+
+joyboard is still early (lowercase letters and some punctuation today), with much more planned —
+a fuller character set, configurable layouts, CI, and an ecosystem around it. See
+[ROADMAP.md](ROADMAP.md) for where the project is headed.
 
 ## License
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,58 @@
+# Roadmap
+
+This document captures where `joyboard` is headed. Today (v0.0.1, beta) you can type lowercase
+letters and some punctuation, delete (backspace), insert newline/tab, and move the cursor with the
+right stick — see the [README](README.md#controls) for the full layout.
+
+The work below is grouped into themes rather than fixed releases. Ordering within each section
+roughly reflects priority, but nothing here is a commitment — it's a direction, and it will change.
+Contributions and suggestions are welcome.
+
+## Input & Character Set
+
+- [ ] **Uppercase letters** via a shift/modifier layer (today the layout is lowercase only).
+- [ ] **Digits 0-9 and extended punctuation** so joyboard can type more than prose.
+- [ ] **More character layers** using inputs that are already detected but unused: the shoulder,
+      stick-click, and menu buttons (`LB, RB, <, >, LA, RA, M`) and the trigger pad.
+- [ ] **Stenographic chording** — selecting whole words with simultaneous presses, the long-term
+      vision described in the README.
+
+## Configuration
+
+- [ ] **External layout files** so users can remap characters without editing the source table.
+- [ ] **Tunable timings** — make the debounce delays (currently fixed at 0.1s / 0.3s) and the
+      polling rate (currently 60 FPS) configurable.
+- [ ] **Command-line options** for layout selection, controller index, and timing tweaks.
+
+## Platform & Robustness
+
+- [ ] **Graceful failure handling** for controller disconnects and input/init errors instead of
+      crashing.
+- [ ] **Multi-controller and hot-plug support** (currently only the first controller is used).
+- [ ] **Reduce the Linux `sudo` requirement** where possible, and document the constraint clearly
+      where it can't be avoided.
+
+## Tooling & CI
+
+- [ ] **Continuous integration** — a GitHub Actions workflow running the test suite, format check,
+      and type check on every push and pull request.
+- [ ] **Coverage in CI**, and closing current gaps (the trigger pad and disconnect paths are
+      untested).
+- [ ] **Automated releases** to PyPI on tagged versions.
+
+## Documentation
+
+- [ ] **Keep the layout in sync** — generate the README character table from the in-source table
+      (or vice versa) so they can't drift apart.
+- [ ] **A usage screencast / GIF** showing real typing.
+- [ ] **A layout-design rationale** explaining how characters are placed.
+
+## Ecosystem
+
+- [ ] **A joyboard website** as the project's home: docs, downloads, and an interactive demo.
+- [ ] **A typing-training tool** (browser-based) to help newcomers learn the layout and build
+      speed — think "typing tutor" for the gamepad.
+- [ ] **Sharing of character maps** — a place to publish, browse, and import community layouts
+      (different languages, keyboard styles, accessibility-focused maps).
+- [ ] **Testimonials and showcases** from people using joyboard, including accessibility stories.
+- [ ] **Community spaces** (discussion, issues, contribution guide) to grow participation.


### PR DESCRIPTION
Add ROADMAP.md grouping planned work into themed sections (input &
character set, configuration, platform & robustness, tooling & CI,
documentation, and ecosystem) and link it from the README.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015R8a6byoyZdYxL6xr4tE54